### PR TITLE
fix: add guard against out of bounds error when finding siblings

### DIFF
--- a/lib/src/analyzer.dart
+++ b/lib/src/analyzer.dart
@@ -121,7 +121,13 @@ int _findSiblingIndex(Path consumer, Path dependency) {
   var index = 0;
 
   while (consumer[index] == dependency[index]) {
-    index++;
+    final newIndex = index + 1;
+
+    if (newIndex >= consumer.length || newIndex >= dependency.length) {
+      break;
+    }
+
+    index = newIndex;
   }
 
   return index;


### PR DESCRIPTION
When having folders with additional generated files which are part of other files, generation failed with out of bounds error.

In my case this was when I had this structure

app_router
- app_routes.dart - (includes part directive)
- app_routes.g.dart (includes part of directive)

Adding this guard helped me fix the error. I did not have time to examine the exact logic so please double check if this breaks something elsewhere. However, as this fixed my issue, I am providing the solution as a pull request.