### PR TITLE
Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 3.0.4
 
-* Output content of the diagram, that caused failure.s
+* Output content of the diagram, that caused failures.
 
 # 3.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.4
+
+* Output content of the diagram, that caused failure.s
+
 # 3.0.3
 
 * Fix false positives when `except` is applied.

--- a/example/README.md
+++ b/example/README.md
@@ -1,1 +1,5 @@
+# LayerLens Example
+
 To re-generate diagrams, run `dart run layerlens`.
+
+To check how it fails on cycles, run `dart run layerlens --fail-on-cycles`.

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -35,7 +35,7 @@ final _failureMessages = {
 
 To see the cycles, do one of the following:
 
-* Copy the diagram above and paste it somewhere, where the diagram will be previewed, for example, to a comment on a GitHub PR.
+* Copy the diagram above and paste it somewhere, where the diagram can be previewed, for example, to a comment on a GitHub PR.
 * Regenerate the diagrams by running `layerlens` in the project root and search for '--!--'
 
 The tool failed because the CLI option --${CliOptions.failOnCycles.name} is set.

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -32,7 +32,12 @@ enum CliOptions {
 
 final _failureMessages = {
   FailureCodes.cycles: '''Error: cycles detected.
-To see the cycles, regenerate the diagrams and search for '--!--'.
+
+To see the cycles, do one of the following:
+
+* Copy the diagram above and paste it somewhere, where the diagram will be previewed, for example, to a comment on a GitHub PR.
+* regenerate the diagrams by running `layerlens` in the project root and search for '--!--'
+
 The tool failed because the CLI option --${CliOptions.failOnCycles.name} is set.
 ''',
   FailureCodes.diagramsOutdated: '''Error: diagrams are outdated.

--- a/lib/src/cli.dart
+++ b/lib/src/cli.dart
@@ -36,7 +36,7 @@ final _failureMessages = {
 To see the cycles, do one of the following:
 
 * Copy the diagram above and paste it somewhere, where the diagram will be previewed, for example, to a comment on a GitHub PR.
-* regenerate the diagrams by running `layerlens` in the project root and search for '--!--'
+* Regenerate the diagrams by running `layerlens` in the project root and search for '--!--'
 
 The tool failed because the CLI option --${CliOptions.failOnCycles.name} is set.
 ''',

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 
 import 'cli.dart';
@@ -67,18 +69,20 @@ class MdGenerator {
       return false;
     }
 
-    _handleCycles(
-      failOnCycles: failOnCycles,
-      totalInversions: folder.localInversions,
-    );
-
-    final theContent = content(folder);
-    if (theContent == null) {
+    final diagram = content(folder);
+    if (diagram == null) {
       await deleteDiagramFile(path: filePath, failIfExists: failIfChanged);
       return false;
     }
 
-    await updateDiagramFile(filePath, theContent, failIfChanged);
+    _handleCycles(
+      diagram: diagram,
+      failOnCycles: failOnCycles,
+      inversions: folder.localInversions,
+      path: folder.fullName,
+    );
+
+    await updateDiagramFile(filePath, diagram, failIfChanged);
     return true;
   }
 
@@ -129,9 +133,13 @@ class MdGenerator {
 
   void _handleCycles({
     required bool failOnCycles,
-    required int totalInversions,
+    required int inversions,
+    required String diagram,
+    required String path,
   }) {
-    if (totalInversions > 0 && failOnCycles) {
+    if (inversions > 0 && failOnCycles) {
+      stderr.writeln('Found inversions at $path:');
+      stderr.writeln(diagram);
       failExecution(FailureCodes.cycles, exitFn: exitFn);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: layerlens
-version: 3.0.3
+version: 3.0.4
 description: Generate a dependency diagram in every folder of your source code.
 repository: https://github.com/polina-c/layerlens
 


### PR DESCRIPTION
The tool outputs inversions, not cycles, because:

1. It takes more effort and will introduce complexity to the tool
2. Each inversion can cause many cycles
3. Normally inversions show cycles well
4. To fix layering, it is enough to see inversions

New output:

```
Found inversions at lib:
<!---
Generated by https://github.com/polina-c/layerlens
Dependencies that create loops (inversions) are marked with `!`.
-->

\```mermaid
flowchart TD;
example.dart-->f1.dart;
f1.dart-->f2.dart;
f2.dart--!-->example.dart;
subfolder1-->subfolder2;
\```

### Inversions

In this folder: 1

Including sub-folders: 2

Error: cycles detected.

To see the cycles, do one of the following:

* Copy the diagram above and paste it somewhere, where the diagram will be previewed, for example, to a comment on a GitHub PR.
* regenerate the diagrams by running `layerlens` in the project root and search for '--!--'

Read more at https://pub.dev/packages/layerlens.

```